### PR TITLE
Add bitcoin-orange themed landing page for Blockschmiede

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Blockschmiede | Kryptoberatung & Produkte</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="top-bar">
+        <div class="brand">Blockschmiede</div>
+        <nav class="main-nav">
+            <a href="#unternehmen">Unternehmen</a>
+            <a href="#beratung">Krypto-Beratung</a>
+            <a href="#produkte">Produkte</a>
+        </nav>
+        <a class="top-cta" href="#unternehmen">Testen Sie uns.</a>
+    </header>
+
+    <main>
+        <section class="hero" id="unternehmen">
+            <div class="hero-content">
+                <div class="hero-text">
+                    <h1>Neues Wagen. Erfahrungen sammeln. Horizont erweitern.</h1>
+                    <p>Das ist der Kern unseres Handelns und die Grundlage unserer Beratung.</p>
+                    <p>Seit 2025 stehen wir als Beratungsunternehmen mit eigener Produktschmiede für unabhängige Kryptoberatung.</p>
+                    <p>Mit unserer Berufserfahrung in den Bereichen IT, Technik und Finanzwirtschaft komplettieren wir den Kreis für Ihre individuelle Beratung.</p>
+                    <p>Das digitale Zeitalter hat begonnen und tritt mit dem Thema Krypto in die heiße Phase ein. Trotz des noch sehr jungen Themenbereiches können wir mit unserer über 8-jährigen Erfahrung bereits auf eine stolze Bilanz zurückblicken.</p>
+                    <div class="hero-highlights">
+                        <div class="highlight-card">
+                            <p>Menschen und Unternehmen einen Mehrwehrt bieten, das ist unser Credo.</p>
+                        </div>
+                        <div class="highlight-card">
+                            <p>Wir nehmen uns Zeit um mit Ihnen zu verstehen:</p>
+                        </div>
+                        <div class="highlight-card">
+                            <p>Nur wer die Ausgangssituation, Ziele und Prioritäten des Mandanten kennt, kann fundierte Empfehlungen abgeben.</p>
+                        </div>
+                        <div class="highlight-card">
+                            <p>Testen Sie uns. Egal ob digital oder vor Ort, wir haben immer ein offenes Ohr für die Probleme der „Digitalen Revolution"</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="hero-panels">
+                    <article class="panel-card">
+                        <div class="panel-icon" aria-hidden="true">
+                            <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <rect x="6" y="14" width="36" height="24" rx="8" stroke="currentColor" stroke-width="3"/>
+                                <path d="M16 18V12C16 8.68629 18.6863 6 22 6H26C29.3137 6 32 8.68629 32 12V18" stroke="currentColor" stroke-width="3"/>
+                                <path d="M18 28L21.5 31.5L30 22" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+                            </svg>
+                        </div>
+                        <h3>Krypto-Beratung</h3>
+                        <p>Unser Beratungsprozess folgt einer klaren Struktur, welche Ihnen Transparenz, Orientierung und Sicherheit bietet.</p>
+                        <span class="panel-badge">Analysegespräch</span>
+                    </article>
+                    <article class="panel-card">
+                        <div class="panel-icon" aria-hidden="true">
+                            <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M8 30L24 10L40 30" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+                                <path d="M12 28L24 14L36 28V38H12V28Z" stroke="currentColor" stroke-width="3" stroke-linejoin="round"/>
+                                <path d="M20 38V28H28V38" stroke="currentColor" stroke-width="3" stroke-linejoin="round"/>
+                            </svg>
+                        </div>
+                        <h3>Produkte-Reiter</h3>
+                        <p>Krypto bringt eine ganze Reihe an neuen Produkten mit sich. Wir stehen mit Rat und Tat zur Seite und integrieren bestehende Hardware &amp; Softwarelösungen in unsere Beratung.</p>
+                        <span class="panel-badge">Technik erleben</span>
+                    </article>
+                    <article class="panel-card">
+                        <div class="panel-icon" aria-hidden="true">
+                            <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <circle cx="24" cy="18" r="10" stroke="currentColor" stroke-width="3"/>
+                                <path d="M8 42C9.33333 37.3333 14 28 24 28C34 28 38.6667 37.3333 40 42" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+                            </svg>
+                        </div>
+                        <h3>Menschen und Unternehmen</h3>
+                        <p>Menschen und Unternehmen einen Mehrwehrt bieten, das ist unser Credo.</p>
+                        <span class="panel-badge">Testen Sie uns.</span>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" id="beratung">
+            <div class="section-header">
+                <span class="section-kicker">Krypto-Beratung</span>
+                <h2>Unser Beratungsprozess folgt einer klaren Struktur, welche Ihnen Transparenz, Orientierung und Sicherheit bietet.</h2>
+            </div>
+            <div class="timeline">
+                <article class="timeline-step">
+                    <h3>1. Analysegespräch</h3>
+                    <p>Wagen: Ihre Ziele, Ihre Situation, Ihre Prioritäten Auf dieser Basis entsteht ein tiefes Verständnis, das die Grundlage für jede Strategie ist. Sie wagen sich in einen neuen Bereich und wir unterstützen Sie dabei. Zunächst analysieren wir Ihre persönliche Ausgangssituation: Kenntnisse und Erfahrungen, Ihre Rahmenbedingungen und Lebenssituation.</p>
+                </article>
+                <article class="timeline-step">
+                    <h3>2. Strategiegespräch</h3>
+                    <p>Erfahrungen sammeln: Auf Basis der Analyse entwickeln wir eine maßgeschneiderte, individuelle Lösung. Durchdacht, strukturiert und perfekt an Ihre Anforderungen angepasst. Sie erhalten fundierte Handlungsempfehlungen und zusammen vergleichen wir verschiedene Szenarien. Diese sind für Sie verständlich aufbereitet und werden von uns bis zur vollsten Zufriedenheit mit Ihnen besprochen.</p>
+                </article>
+                <article class="timeline-step">
+                    <h3>3. Umsetzungsgespräch</h3>
+                    <p>Horizont erweitern: Wir setzen zusammen um, koordinieren mit Ihnen alle Schritte und bleiben in der Zukunft immer Ihr verlässlicher Partner - auch wenn sich die Rahmenbedingungen ändern. Unsere Beratung steht für Klarheit im Prozess, Sicherheit in der Entscheidung, Vertrauen in der Umsetzung.</p>
+                </article>
+            </div>
+
+            <div class="principles">
+                <h3>Unser Beratungsverständnis:</h3>
+                <div class="principles-grid">
+                    <article class="principle-card">
+                        <h4>Unabhängigkeit</h4>
+                        <p>Als freie Berater agieren wir unabhängig von Institutionen, Brokern oder gesellschaftlichen Meinungen. Unsere verankerte Rolle ist die dies Sachwalters, wie ihn der Bundesgerichtshof bereits 1985 definiert hat: vergleichbar mit einem Rechtsanwalt in Rechtsfragen oder einem Steuerberater in Steuerfragen.</p>
+                    </article>
+                    <article class="principle-card">
+                        <h4>Fundierte Verantwortung</h4>
+                        <p>Wir verstehen diesen Anspruch nicht nur juristisch, sondern lieben diesen auch: unabhängig und auf unseren eigenen Erfahrungen basierend bieten wir einen objektiven aber fundierten Beratungsansatz.</p>
+                    </article>
+                    <article class="principle-card">
+                        <h4>Kontinuierliche Arbeit</h4>
+                        <p>Kontinuierliche Arbeit: Wir sondieren den Markt, prüfen selbst sämtliche Anbieter und Produkte bevor wir diese in unseren Beratungsprozess einbinden.</p>
+                    </article>
+                    <article class="principle-card">
+                        <h4>Marktführerschaft als Ziel</h4>
+                        <p>Mit dem Anspruch, qualitative Marktführerschaft im DACH-Raum zu erreichen, möchten wir uns zu einem führenden Ansprechpartner im Bereich Krypto entwickeln.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" id="produkte">
+            <div class="section-header">
+                <span class="section-kicker">Produkte</span>
+                <h2>Krypto bringt eine ganze Reihe an neuen Produkten mit sich. Wir stehen mit Rat und Tat zur Seite und integrieren bestehende Hardware &amp; Softwarelösungen in unsere Beratung. Ein zusätzlich sehr wichtiger Bereich ist die eigene Entwicklung von Produkten, Softwarelösungen und Infrastrukturanbindungen.</h2>
+            </div>
+
+            <div class="product-grid">
+                <article class="product-card">
+                    <h3>Technik erleben</h3>
+                    <p>Technik erleben: Wir helfen Ihnen dabei alle technische Neuerung aus dem Bereich Krypto erleben zu können. In unseren Beratungen setzen wir gezielt bereits etablierte Produkte und System ein. Dabei garantieren wir einen einzigartigen Erlebnisfaktor. Maßgeschneiderte Lösungen? Unser Anspruch!</p>
+                </article>
+                <article class="product-card">
+                    <h3>Fortschritt spüren</h3>
+                    <p>Fortschritt spüren: Krypto ist mehr als ein paar Coins. Die digitale Revolution hat begonnen! Selbstverständlich entwickeln wir auch eigene Produkte und Dienstleistungen rund um das Thema Krypto. Made in Germany, für uns nicht nur ein in die Jahre gekommener Slogan. Wir wollen mit unseren Produkt und Softwareentwicklungen aktiv dazu beitragen, dass Deutschland künftig ein Vorreiter im digitalen Zeitalter wird.</p>
+                </article>
+                <article class="product-card">
+                    <h3>Die Zukunft gestalten</h3>
+                    <p>Die Zukunft gestalten: Egal ob Privatperson oder Unternehmen. Wir haben neben unserer Beratung auch alle passenden Produkte zur Hand. Clever integriert und um unsere eigene maßgeschneiderte Infrastruktur ergänzt, befördern wir Sie und Ihr Unternehmen in das digitale Kryptozeitalter</p>
+                </article>
+            </div>
+
+            <div class="product-cta">
+                <div class="cta-text">
+                    <h3>Maßgeschneidert oder etwas von der Stange?</h3>
+                    <p>Von der einfachen Coldwallet, über den Nodebau mit Anleitung und Hilfestellung, bis hin zu einer eigenen Krypto Infrastruktur für Ihr Unternehmen. Wir setzen Technik zielgerichtet und sinnvoll ein, dafür stehen wir mit unserem Namen.</p>
+                </div>
+                <div class="cta-text">
+                    <p>Durch unsere langjährige Erfahrung im Bereich Krypto, können wir auf ein breites Spektrum an Technik und Lösungsansätze zurückgreifen.</p>
+                    <p>Was uns unterscheidet: Sie stehen im Mittelpunkt der Lösung</p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>Blockschmiede · Horizont erweitern</p>
+    </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,469 @@
+:root {
+    --bg: #0c1017;
+    --surface: #131a26;
+    --surface-soft: #1a2231;
+    --card: rgba(19, 26, 38, 0.86);
+    --text: #f5f6fa;
+    --muted: #b4c0d4;
+    --accent: #f7931a;
+    --accent-soft: rgba(247, 147, 26, 0.16);
+    --border: rgba(255, 255, 255, 0.08);
+    --shadow: 0 28px 40px rgba(4, 8, 20, 0.4);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Manrope', 'Segoe UI', sans-serif;
+    background: radial-gradient(circle at top left, rgba(247, 147, 26, 0.16), transparent 45%),
+                radial-gradient(circle at 80% 0%, rgba(247, 147, 26, 0.08), transparent 35%),
+                linear-gradient(160deg, #07090f, var(--bg) 45%, #080b12 100%);
+    color: var(--text);
+    line-height: 1.7;
+    min-height: 100vh;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.top-bar {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.25rem 8%;
+    background: rgba(10, 13, 20, 0.85);
+    backdrop-filter: blur(18px);
+    border-bottom: 1px solid var(--border);
+}
+
+.brand {
+    font-weight: 700;
+    font-size: 1.2rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.main-nav {
+    display: flex;
+    gap: 1.5rem;
+}
+
+.main-nav a {
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    position: relative;
+    padding-bottom: 0.2rem;
+}
+
+.main-nav a::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 2px;
+    background: linear-gradient(135deg, var(--accent), #ffae42);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.3s ease;
+}
+
+.main-nav a:hover::after,
+.main-nav a:focus-visible::after {
+    transform: scaleX(1);
+}
+
+.top-cta {
+    padding: 0.6rem 1.4rem;
+    font-weight: 600;
+    border-radius: 999px;
+    border: 1px solid rgba(247, 147, 26, 0.4);
+    background: linear-gradient(135deg, rgba(247, 147, 26, 0.15), rgba(247, 147, 26, 0.05));
+    box-shadow: inset 0 0 0 1px rgba(247, 147, 26, 0.08);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.top-cta:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 25px rgba(247, 147, 26, 0.3);
+}
+
+.hero {
+    position: relative;
+    padding: 6rem 8% 4rem;
+    overflow: hidden;
+}
+
+.hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 10% 20%, rgba(247, 147, 26, 0.2), transparent 55%),
+                radial-gradient(circle at 90% 15%, rgba(247, 147, 26, 0.12), transparent 45%);
+    opacity: 0.8;
+    pointer-events: none;
+}
+
+.hero-content {
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(280px, 1.2fr) minmax(260px, 1fr);
+    gap: 3rem;
+    align-items: start;
+}
+
+.hero-text h1 {
+    font-size: clamp(2.2rem, 4vw, 3.1rem);
+    line-height: 1.1;
+    margin-bottom: 1rem;
+}
+
+.hero-text p {
+    margin: 0 0 1rem;
+    color: var(--muted);
+}
+
+.hero-highlights {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(160px, 1fr));
+    gap: 1rem;
+    margin-top: 2.5rem;
+}
+
+.highlight-card {
+    background: rgba(12, 16, 24, 0.8);
+    border: 1px solid rgba(247, 147, 26, 0.18);
+    border-radius: 1.25rem;
+    padding: 1.25rem;
+    box-shadow: 0 16px 35px rgba(6, 8, 14, 0.4);
+    position: relative;
+}
+
+.highlight-card::before {
+    content: '';
+    position: absolute;
+    top: -0.5rem;
+    right: -0.5rem;
+    width: 2.25rem;
+    height: 2.25rem;
+    background: rgba(247, 147, 26, 0.25);
+    filter: blur(18px);
+    border-radius: 50%;
+}
+
+.hero-panels {
+    display: grid;
+    gap: 1.8rem;
+}
+
+.panel-card {
+    background: var(--card);
+    border-radius: 1.5rem;
+    padding: 2.25rem 2rem;
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow);
+    position: relative;
+    overflow: hidden;
+    backdrop-filter: blur(6px);
+    transition: transform 0.3s ease;
+}
+
+.panel-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(247, 147, 26, 0.18), transparent 55%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.panel-card:hover {
+    transform: translateY(-6px);
+}
+
+.panel-card:hover::after {
+    opacity: 1;
+}
+
+.panel-icon {
+    width: 3.2rem;
+    height: 3.2rem;
+    border-radius: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent);
+    background: rgba(247, 147, 26, 0.15);
+    margin-bottom: 1.5rem;
+    position: relative;
+}
+
+.panel-card h3 {
+    margin: 0 0 0.75rem;
+    font-size: 1.2rem;
+}
+
+.panel-card p {
+    margin: 0 0 1.4rem;
+    color: var(--muted);
+}
+
+.panel-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.45rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(247, 147, 26, 0.16);
+    color: var(--accent);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.section {
+    padding: 6rem 8%;
+}
+
+.section-header {
+    max-width: 860px;
+    margin: 0 auto 3.5rem;
+    text-align: center;
+}
+
+.section-kicker {
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    font-size: 0.85rem;
+    display: inline-block;
+    background: rgba(247, 147, 26, 0.1);
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    color: var(--accent);
+    margin-bottom: 1rem;
+}
+
+.section-header h2 {
+    margin: 0;
+    font-size: clamp(1.8rem, 3vw, 2.4rem);
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.timeline {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 2.5rem;
+    counter-reset: step;
+}
+
+.timeline-step {
+    position: relative;
+    background: var(--surface-soft);
+    border-radius: 1.75rem;
+    border: 1px solid rgba(247, 147, 26, 0.18);
+    padding: 2.8rem 2.1rem 2.1rem;
+    box-shadow: 0 32px 45px rgba(3, 7, 16, 0.45);
+    overflow: hidden;
+}
+
+.timeline-step::before {
+    counter-increment: step;
+    content: counter(step);
+    position: absolute;
+    top: -1.1rem;
+    left: 2rem;
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--accent), #ffae42);
+    color: #1c1205;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 15px 32px rgba(247, 147, 26, 0.35);
+}
+
+.timeline-step h3 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-size: 1.3rem;
+}
+
+.timeline-step p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.principles {
+    margin-top: 4.5rem;
+}
+
+.principles h3 {
+    margin-bottom: 2rem;
+    text-align: center;
+    font-size: 1.6rem;
+}
+
+.principles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.8rem;
+}
+
+.principle-card {
+    background: var(--surface);
+    border-radius: 1.5rem;
+    border: 1px solid var(--border);
+    padding: 2rem;
+    box-shadow: 0 24px 40px rgba(3, 6, 14, 0.35);
+    position: relative;
+    overflow: hidden;
+}
+
+.principle-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(145deg, rgba(247, 147, 26, 0.12), transparent 60%);
+    pointer-events: none;
+}
+
+.principle-card h4 {
+    margin-top: 0;
+    margin-bottom: 0.8rem;
+    font-size: 1.1rem;
+}
+
+.principle-card p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.product-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.8rem;
+}
+
+.product-card {
+    background: var(--surface);
+    border-radius: 1.6rem;
+    border: 1px solid rgba(247, 147, 26, 0.16);
+    padding: 2.2rem 2rem;
+    box-shadow: 0 26px 45px rgba(3, 5, 12, 0.4);
+    transition: transform 0.3s ease;
+}
+
+.product-card:hover {
+    transform: translateY(-8px);
+}
+
+.product-card h3 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-size: 1.25rem;
+}
+
+.product-card p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.product-cta {
+    margin-top: 3.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 2.2rem;
+    background: rgba(8, 11, 18, 0.7);
+    border-radius: 1.75rem;
+    padding: 2.5rem;
+    border: 1px solid rgba(247, 147, 26, 0.2);
+    box-shadow: 0 40px 60px rgba(2, 5, 12, 0.45);
+}
+
+.product-cta h3 {
+    margin-top: 0;
+    margin-bottom: 1.2rem;
+    font-size: 1.3rem;
+}
+
+.product-cta p {
+    margin: 0 0 1rem;
+    color: var(--muted);
+}
+
+.site-footer {
+    padding: 3rem 8%;
+    text-align: center;
+    color: rgba(255, 255, 255, 0.6);
+    border-top: 1px solid var(--border);
+    background: rgba(8, 10, 16, 0.85);
+}
+
+@media (max-width: 1024px) {
+    .hero-content {
+        grid-template-columns: 1fr;
+    }
+
+    .hero-panels {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+}
+
+@media (max-width: 768px) {
+    .top-bar {
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+
+    .main-nav {
+        width: 100%;
+        justify-content: center;
+        order: 3;
+    }
+
+    .top-cta {
+        order: 2;
+    }
+
+    .hero {
+        padding-top: 5rem;
+    }
+
+    .hero-highlights {
+        grid-template-columns: 1fr;
+    }
+
+    .section {
+        padding: 4.5rem 6%;
+    }
+}
+
+@media (max-width: 560px) {
+    .top-bar {
+        padding: 1rem 1.5rem;
+    }
+
+    .section {
+        padding: 4rem 1.5rem;
+    }
+
+    .panel-card,
+    .product-card,
+    .principle-card {
+        padding: 1.8rem 1.5rem;
+    }
+
+    .product-cta {
+        padding: 2rem 1.5rem;
+    }
+}


### PR DESCRIPTION
## Summary
- create a hero section that showcases the Unternehmensinhalte with highlight cards and bitcoin-orange accent cards for each Reiter
- lay out the Krypto-Beratung Prozess as an illustrated three-step timeline and add principle cards with the provided copy
- present the Produkte-Text in responsive cards and supporting callouts, all styled with a bitcoin-orange dark theme

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d03a2fedd8832291fcd26a985263a3