### PR TITLE
Adjust header imagery sizing and contact widget icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     </script>
 </head>
 <body>
-    <header class="site-header">
+    <header class="site-header site-header--home">
         <div class="top-bar">
             <a class="brand" href="index.html">
                 <img src="img/logo.png" alt="Blockschmiede Logo">

--- a/index.html
+++ b/index.html
@@ -99,19 +99,16 @@
                 <div class="hero-impressions" aria-label="Impressionen" data-animate style="--animate-delay: 0.12s;">
                     <div class="mosaic">
                         <article class="mosaic-card" data-animate style="--animate-delay: 0.18s;">
-                            <span class="mosaic-stat">&gt; 8 Jahre Erfahrung</span>
                             <h4>Krypto-Beratung</h4>
                             <p>Unser Beratungsprozess folgt einer klaren Struktur, die Ihnen Transparenz, Orientierung und Sicherheit bietet.</p>
                             <p class="mosaic-note">Analysegespräch · Strategiegespräch · Umsetzungsgespräch</p>
                         </article>
                         <article class="mosaic-card" data-animate style="--animate-delay: 0.24s;">
-                            <span class="mosaic-stat">&gt; 100.000 Coins</span>
                             <h4>Produkte</h4>
                             <p>Krypto bringt eine ganze Reihe an neuen Produkten mit sich. Wir integrieren bestehende Hardware &amp; Softwarelösungen in unsere Beratung.</p>
                             <p class="mosaic-note">Technik erleben · Fortschritt spüren · Die Zukunft gestalten</p>
                         </article>
                         <article class="mosaic-card" data-animate style="--animate-delay: 0.3s;">
-                            <span class="mosaic-stat">&gt; 100 Nodes</span>
                             <h4>Unternehmen</h4>
                             <p>Seit 2025 stehen wir als Beratungsunternehmen mit eigener Produktschmiede für unabhängige Kryptoberatung.</p>
                             <p class="mosaic-note">Neues wagen · Erfahrungen sammeln · Horizont erweitern</p>

--- a/legacy21.html
+++ b/legacy21.html
@@ -50,7 +50,7 @@
         </div>
         <div class="header-visual header-visual--fullimage" data-animate>
             <div class="header-image-frame" data-animate>
-                <img src="img/Produkte.png" alt="Abstraktes Headerbild der Legacy 21 Karte" class="header-image">
+                <img src="img/legacy21/2.png" alt="Abstraktes Headerbild der Legacy 21 Karte" class="header-image">
             </div>
         </div>
     </header>
@@ -64,7 +64,7 @@
                             <span class="legacy-card-motto">Not your Card, not your Coins.</span>
                         </div>
                         <div class="legacy-card legacy-card-front">
-                            <span class="legacy-card-badge">Made in Germany</span>
+                            <span class="legacy-card-badge"></span>
                             <span class="legacy-card-label">Legacy 21 Karte</span>
                             <p class="legacy-card-tagline">Verschenke Bitcoin mit Stil und ermögliche einen sicheren Start.</p>
                             <ul class="legacy-card-points">

--- a/produkte.html
+++ b/produkte.html
@@ -48,9 +48,9 @@
                 </ul>
             </nav>
         </div>
-        <div class="header-visual header-visual--fullimage" data-animate>
+        <div class="header-visual header-visual--fullimage" data-animate >
             <div class="header-image-frame" data-animate>
-                <img src="img/Produkte.png" alt="Abstraktes Headerbild der Legacy 21 Karte" class="header-image">
+                <img src="img/Produkte.png" alt="Abstraktes Headerbild der Legacy 21 Karte" class="header-image" style="object-position: bottom;">
             </div>
         </div>
     </header>

--- a/style.css
+++ b/style.css
@@ -211,7 +211,7 @@ main {
 .header-visual--fullimage .header-image-frame {
     width: 100%;
     max-width: none;
-    height: clamp(240px, 38vh, 420px);
+    max-height: 900px;
     overflow: hidden;
 }
 
@@ -222,7 +222,8 @@ main {
 .header-visual--fullimage .header-image {
     display: block;
     width: 100%;
-    height: 100%;
+    height: auto;
+    max-height: 900px;
     object-fit: cover;
 }
 
@@ -767,15 +768,6 @@ main {
 }
 
 @media (min-width: 960px) {
-    .intro-cards {
-        flex-direction: row;
-        align-items: stretch;
-    }
-
-    .intro-card {
-        flex: 1;
-    }
-
     .mosaic {
         grid-template-columns: repeat(3, minmax(0, 1fr));
     }
@@ -2034,11 +2026,15 @@ main {
     }
 
     .header-visual--fullimage .header-image-frame {
-        width: 100vw;
-        margin-left: calc(50% - 50vw);
-        margin-right: calc(50% - 50vw);
+        width: 100%;
+        margin-left: 0;
+        margin-right: 0;
         border-radius: 0;
-        height: clamp(260px, 60vh, 520px);
+        max-height: none;
+    }
+
+    .header-visual--fullimage .header-image {
+        max-height: none;
     }
 
     .site-header--home .header-disclaimer {

--- a/style.css
+++ b/style.css
@@ -208,12 +208,22 @@ main {
     width: 100%;
 }
 
+.header-visual--fullimage .header-image-frame {
+    width: 100%;
+    max-width: none;
+    height: clamp(240px, 38vh, 420px);
+    overflow: hidden;
+}
+
 .header-visual--fullimage .header-image-frame::before {
     display: none;
 }
 
 .header-visual--fullimage .header-image {
     display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 .header-visual--fullimage .header-disclaimer {
@@ -245,6 +255,10 @@ main {
     border-bottom: 1px solid rgba(255, 190, 190, 0.45);
     backdrop-filter: blur(8px);
     z-index: 2;
+}
+
+.site-header--home .header-disclaimer {
+    top: calc(var(--safe-top) + 1.1rem);
 }
 
 .header-card-text {
@@ -1240,6 +1254,7 @@ main {
     background-repeat: no-repeat;
     background-position: center;
     filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.35));
+    transform: translateY(-1px);
 }
 
 .floating-contact__glyph::after {
@@ -1370,7 +1385,7 @@ main {
 }
 
 .floating-contact__action--whatsapp .floating-contact__icon {
-    --contact-icon: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23f7931a%27%20stroke-width%3D%271.8%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20d%3D%27M4.3%2019.2%205.8%2015A8.5%208.5%200%201%201%2015%2020.2l-4.2%201.5z%27/%3E%3Cpath%20d%3D%27M8.8%2010.5c.3%201.3%201.5%203%202.8%203.6%201.1.5%201.7.5%202.3-.3.5-.6.8-1%20.4-1.8-.3-.6-.9-.3-1.5-.1-.6.2-.9-.1-1.3-.5-.7-.5-1.2-1.1-1.5-1.9-.3-.6-.1-1%20.3-1.4s.6-1%20.2-1.6c-.5-.8-1-.9-1.5-.6-.6.3-1.4%201.2-1.2%202.6z%27/%3E%3C/svg%3E");
+    --contact-icon: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23f7931a%27%20stroke-width%3D%271.8%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20d%3D%27M5%204h14a3%203%200%200%201%203%203v7a3%203%200%200%201-3%203h-6l-4%204v-4H5a3%203%200%200%201-3-3V7a3%203%200%200%201%203-3Z%27/%3E%3Cpath%20d%3D%27M8%209h8%27/%3E%3Cpath%20d%3D%27M8%2013h5%27/%3E%3C/svg%3E");
 }
 
 .floating-contact__action--mail .floating-contact__icon {
@@ -2016,6 +2031,18 @@ main {
 @media (max-width: 768px) {
     body {
         line-height: 1.6;
+    }
+
+    .header-visual--fullimage .header-image-frame {
+        width: 100vw;
+        margin-left: calc(50% - 50vw);
+        margin-right: calc(50% - 50vw);
+        border-radius: 0;
+        height: clamp(260px, 60vh, 520px);
+    }
+
+    .site-header--home .header-disclaimer {
+        top: calc(var(--safe-top) + 0.8rem);
     }
 
     .top-bar {

--- a/style.css
+++ b/style.css
@@ -211,7 +211,7 @@ main {
 .header-visual--fullimage .header-image-frame {
     width: 100%;
     max-width: none;
-    max-height: 900px;
+    max-height: 700px;
     overflow: hidden;
 }
 
@@ -596,7 +596,7 @@ main {
 
 .hero {
     position: relative;
-    padding: 6rem 8% 4rem;
+    padding: 4rem 8% 4rem;
     padding-inline-start: calc(8% + var(--safe-left));
     padding-inline-end: calc(8% + var(--safe-right));
     overflow: hidden;
@@ -1478,7 +1478,7 @@ main {
     position: absolute;
     inset: 0;
     border-radius: 1.6rem;
-    padding: 2.3rem;
+    padding: 1.3rem;
     display: flex;
     flex-direction: column;
     gap: 1.1rem;
@@ -1573,7 +1573,7 @@ main {
     border-radius: 1.2rem;
     background: rgba(255, 255, 255, 0.05);
     border: 1px solid rgba(255, 255, 255, 0.08);
-    display: flex;
+    flex-direction: row;
     align-items: center;
     gap: 1rem;
     box-shadow: 0 18px 34px rgba(0, 0, 0, 0.32);


### PR DESCRIPTION
## Summary
- limit the header visuals to a shorter height on large screens and stretch them edge-to-edge on mobile
- reposition the home page sales disclaimer so it is visible below the sticky navigation
- align the floating contact glyph and switch the WhatsApp action to a speech bubble icon

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d46905c23c8322b92229ce839b8f7b