### PR TITLE
Fix Legacy21 video embed layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -2122,16 +2122,19 @@ svg.usecase-icon {
     position: relative;
     border-radius: 1.2rem;
     background: linear-gradient(145deg, rgba(var(--accent-rgb), 0.24), rgba(var(--accent-rgb), 0.08));
-    aspect-ratio: 16 / 9;
-    display: grid;
-    place-items: center;
+    width: 100%;
+    padding-top: 56.25%;
     overflow: hidden;
 }
 
 .video-frame iframe {
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100%;
     border: 0;
+    display: block;
+    z-index: 0;
 }
 
 .video-frame::after {
@@ -2141,6 +2144,7 @@ svg.usecase-icon {
     background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.24), transparent 55%);
     mix-blend-mode: screen;
     pointer-events: none;
+    z-index: 1;
 }
 
 .video-play-icon {


### PR DESCRIPTION
## Summary
- ensure the Legacy21 explainer video iframe fills the video card responsively
- adjust the iframe positioning so the embed remains clickable across viewports

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d6420b86ec8322af01e6be5f9e8969